### PR TITLE
Support different port and base url in blocklist updates

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -61,7 +61,7 @@ class transmission::config {
 
   cron { 'transmission_update_blocklist':
     ensure  => $::transmission::params::cron_ensure,
-    command => "/usr/bin/transmission-remote${::transmission::params::remote_command_auth} --blocklist-update > /dev/null",
+    command => "/usr/bin/transmission-remote http://localhost:${::transmission::rpc_port}${::transmission::rpc_url} ${::transmission::params::remote_command_auth} --blocklist-update > /dev/null",
     require => Package['transmission-cli','transmission-common','transmission-daemon'],
     user    => 'root',
     minute  => '0',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,7 +34,7 @@ class transmission::install {
 
   if $::transmission::blocklist_url != 'http://www.example.com/blocklist' and $::transmission::service_ensure != 'running' {
     exec { 'transmission_download_blocklists':
-      command => "/usr/bin/transmission-remote${::transmission::params::remote_command_auth} --blocklist-update > /dev/null",
+      command => "/usr/bin/transmission-remote http://localhost:${::transmission::rpc_port}${::transmission::rpc_url} ${::transmission::params::remote_command_auth} --blocklist-update > /dev/null",
       creates => "${::transmission::params::home_dir}/blocklists/blocklist.bin",
       require => Service['transmission-daemon'],
     }


### PR DESCRIPTION
Add rpc_port and rpc_url in the Exec and Cron resources for updating
the blocklist. Hardcode the host for now to localhost as the module
implicitly assumes that anyway.  This doesn't constitute a change from
the default which is per transmission-remote's manpage localhost:9091 so
there should be no change for most installations and would just add
support for the few that override the rpc_port and rpc_url

Signed-off-by: Alexandros Kosiaris <akosiaris@gmail.com>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
